### PR TITLE
Setting max sip version that it's compatible with PyQt 5.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   build:
-	    # We may want to find and add a Python dbus library?
+    # We may want to find and add a Python dbus library?
     # pkg-config --cflags-only-I --libs dbus-1
     # The Python dbus module doesn't seem to be installed.
     - {{ compiler('cxx') }}
@@ -50,12 +50,12 @@ requirements:
     - pkg-config  # [not win]
   host:
     - python
-    - sip >=4.19.4
+    - sip >=4.19.4,<=4.19.8
     - dbus  # [not win]
     - qt 5.9.*
   run:
     - python
-    - sip >=4.19.4
+    - sip >=4.19.4,<=4.19.8
     - qt 5.9.*
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha1: 058c5b37981b515cc4e16faa04a4a6d8892cdaa9
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win and py27]
   run_exports:
     {{ pin_subpackage('pyqt', max_pin='x.x') }}


### PR DESCRIPTION
Right now the pyqt conda packages can generate odd segfaults because they're trying to use sip **4.19.12**, which was uploaded last week to defaults and it's incompatible with pyqt 5.9.