### PR TITLE
upstream patch from pyqt5.11

### DIFF
--- a/recipe/0002-Release-gil-qquickwidgets-setsource.patch
+++ b/recipe/0002-Release-gil-qquickwidgets-setsource.patch
@@ -1,0 +1,11 @@
+--- work/sip/QtQuickWidgets/qquickwidget.sip.orig	2018-11-07 10:57:28.217594671 +0100
++++ work/sip/QtQuickWidgets/qquickwidget.sip	2018-11-07 10:56:08.221371298 +0100
+@@ -67,7 +67,7 @@
+     QSurfaceFormat format() const;
+ 
+ public slots:
+-    void setSource(const QUrl &);
++    void setSource(const QUrl &) /ReleaseGIL/;
+ 
+ signals:
+     void statusChanged(QQuickWidget::Status);

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha1: 058c5b37981b515cc4e16faa04a4a6d8892cdaa9
   patches:
     - 0001-Ignore-lack-of-shared-python-lib.patch
+    - 0002-Release-gil-qquickwidgets-setsource.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win and py27]
   skip: true  # [ppc64le]
   run_exports:


### PR DESCRIPTION
The problem is first reported at anaconda-issues #10124. This patch
derives from upstream pyqt5.11 release.