### PR TITLE
Update to 5.10.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
-# the conda-build parameters to use for disabling --skip-existing
-build_parameters:
-  - ""
-
+channels:
+  - https://staging.continuum.io/prefect/fs/sip-feedstock/pr6/7278ca7
+  - https://staging.continuum.io/prefect/fs/pyqt-builder-feedstock/pr2/7094ac7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/sip-feedstock/pr6/aa5fa92
-  - https://staging.continuum.io/prefect/fs/pyqt-builder-feedstock/pr2/7094ac7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/sip-feedstock/pr6/7278ca7
+  - https://staging.continuum.io/prefect/fs/sip-feedstock/pr6/aa5fa92
   - https://staging.continuum.io/prefect/fs/pyqt-builder-feedstock/pr2/7094ac7

--- a/recipe/bld-pyqt-sip.bat
+++ b/recipe/bld-pyqt-sip.bat
@@ -1,3 +1,3 @@
 pushd pyqt_sip
-%PYTHON% -m pip install . -vv
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/build-pyqt-sip.sh
+++ b/recipe/build-pyqt-sip.sh
@@ -1,22 +1,6 @@
 set -exou
 
+cd $SRC_DIR
+
 pushd pyqt_sip
-
-if [[ $(uname) == "Linux" ]]; then
-    USED_BUILD_PREFIX=${BUILD_PREFIX:-${PREFIX}}
-    echo USED_BUILD_PREFIX=${BUILD_PREFIX}
-
-    ln -s ${GXX} g++ || true
-    ln -s ${GCC} gcc || true
-    ln -s ${USED_BUILD_PREFIX}/bin/${HOST}-gcc-ar gcc-ar || true
-
-    export LD=${GXX}
-    export CC=${GCC}
-    export CXX=${GXX}
-    export PKG_CONFIG_EXECUTABLE=$(basename $(which pkg-config))
-
-    chmod +x g++ gcc gcc-ar
-    export PATH=${PWD}:${PATH}
-fi
-
-$PYTHON setup.py install
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/build-pyqt.sh
+++ b/recipe/build-pyqt.sh
@@ -3,52 +3,17 @@ set -exou
 pushd pyqt
 cp LICENSE ..
 
-SIP_COMMAND="sip-build"
-EXTRA_FLAGS=""
-
-if [[ $(uname) == "Linux" ]]; then
-    USED_BUILD_PREFIX=${BUILD_PREFIX:-${PREFIX}}
-    echo USED_BUILD_PREFIX=${BUILD_PREFIX}
-
-    ln -s ${GXX} g++ || true
-    ln -s ${GCC} gcc || true
-    ln -s ${USED_BUILD_PREFIX}/bin/${HOST}-gcc-ar gcc-ar || true
-
-    export LD=${GXX}
-    export CC=${GCC}
-    export CXX=${GXX}
-    export PKG_CONFIG_EXECUTABLE=$(basename $(which pkg-config))
-
-    chmod +x g++ gcc gcc-ar
-    export PATH=${PWD}:${PATH}
-
-    SYSROOT_FLAGS="-L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64 -L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib"
-    export CFLAGS="$SYSROOT_FLAGS $CFLAGS"
-    export CXXFLAGS="$SYSROOT_FLAGS $CXXFLAGS"
-    export LDFLAGS="$SYSROOT_FLAGS $LDFLAGS"
-fi
-
 if [[ $(uname) == "Darwin" ]]; then
     # Use xcode-avoidance scripts
     export PATH=$PREFIX/bin/xc-avoidance:$PATH
 fi
 
-SIP_COMMAND="$BUILD_PREFIX/bin/python -m sipbuild.tools.build"
-SITE_PKGS_PATH=$($PREFIX/bin/python -c 'import site;print(site.getsitepackages()[0])')
-EXTRA_FLAGS="--target-dir $SITE_PKGS_PATH"
-
-$SIP_COMMAND \
+sip-build \
 --verbose \
 --confirm-license \
---no-make \
-$EXTRA_FLAGS
+--no-make
 
 pushd build
-
-# Make sure BUILD_PREFIX sip-distinfo is called instead of the HOST one
-cat Makefile | sed -r 's|\t(.*)sip-distinfo(.*)|\t'$BUILD_PREFIX/bin/python' -m sipbuild.distinfo.main \2|' > Makefile.temp
-rm Makefile
-mv Makefile.temp Makefile
 
 CPATH=$PREFIX/include make -j$CPU_COUNT
 make install

--- a/recipe/build-pyqt.sh
+++ b/recipe/build-pyqt.sh
@@ -3,6 +3,28 @@ set -exou
 pushd pyqt
 cp LICENSE ..
 
+if [[ $(uname) == "Linux" ]]; then
+    USED_BUILD_PREFIX=${BUILD_PREFIX:-${PREFIX}}
+    echo USED_BUILD_PREFIX=${BUILD_PREFIX}
+
+    ln -s ${GXX} g++ || true
+    ln -s ${GCC} gcc || true
+    ln -s ${USED_BUILD_PREFIX}/bin/${HOST}-gcc-ar gcc-ar || true
+
+    export LD=${GXX}
+    export CC=${GCC}
+    export CXX=${GXX}
+    export PKG_CONFIG_EXECUTABLE=$(basename $(which pkg-config))
+
+    chmod +x g++ gcc gcc-ar
+    export PATH=${PWD}:${PATH}
+
+    SYSROOT_FLAGS="-L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64 -L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib"
+    export CFLAGS="$SYSROOT_FLAGS $CFLAGS"
+    export CXXFLAGS="$SYSROOT_FLAGS $CXXFLAGS"
+    export LDFLAGS="$SYSROOT_FLAGS $LDFLAGS"
+fi
+
 if [[ $(uname) == "Darwin" ]]; then
     # Use xcode-avoidance scripts
     export PATH=$PREFIX/bin/xc-avoidance:$PATH

--- a/recipe/build-pyqtcharts.sh
+++ b/recipe/build-pyqtcharts.sh
@@ -31,8 +31,7 @@ fi
 
 sip-build \
 --verbose \
---no-make \
-$EXTRA_FLAGS
+--no-make
 
 pushd build
 

--- a/recipe/build-pyqtcharts.sh
+++ b/recipe/build-pyqtcharts.sh
@@ -2,6 +2,28 @@ set -exou
 
 pushd pyqt_charts
 
+if [[ $(uname) == "Linux" ]]; then
+    USED_BUILD_PREFIX=${BUILD_PREFIX:-${PREFIX}}
+    echo USED_BUILD_PREFIX=${BUILD_PREFIX}
+
+    ln -s ${GXX} g++ || true
+    ln -s ${GCC} gcc || true
+    ln -s ${USED_BUILD_PREFIX}/bin/${HOST}-gcc-ar gcc-ar || true
+
+    export LD=${GXX}
+    export CC=${GCC}
+    export CXX=${GXX}
+    export PKG_CONFIG_EXECUTABLE=$(basename $(which pkg-config))
+
+    chmod +x g++ gcc gcc-ar
+    export PATH=${PWD}:${PATH}
+
+    SYSROOT_FLAGS="-L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64 -L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib"
+    export CFLAGS="$SYSROOT_FLAGS $CFLAGS"
+    export CXXFLAGS="$SYSROOT_FLAGS $CXXFLAGS"
+    export LDFLAGS="$SYSROOT_FLAGS $LDFLAGS"
+fi
+
 if [[ $(uname) == "Darwin" ]]; then
     # Use xcode-avoidance scripts
     export PATH=$PREFIX/bin/xc-avoidance:$PATH

--- a/recipe/build-pyqtcharts.sh
+++ b/recipe/build-pyqtcharts.sh
@@ -2,55 +2,17 @@ set -exou
 
 pushd pyqt_charts
 
-SIP_COMMAND="sip-build"
-EXTRA_FLAGS=""
-
-if [[ $(uname) == "Linux" ]]; then
-    USED_BUILD_PREFIX=${BUILD_PREFIX:-${PREFIX}}
-    echo USED_BUILD_PREFIX=${BUILD_PREFIX}
-
-    ln -s ${GXX} g++ || true
-    ln -s ${GCC} gcc || true
-    ln -s ${USED_BUILD_PREFIX}/bin/${HOST}-gcc-ar gcc-ar || true
-
-    export LD=${GXX}
-    export CC=${GCC}
-    export CXX=${GXX}
-    export PKG_CONFIG_EXECUTABLE=$(basename $(which pkg-config))
-
-    chmod +x g++ gcc gcc-ar
-    export PATH=${PWD}:${PATH}
-fi
-
 if [[ $(uname) == "Darwin" ]]; then
     # Use xcode-avoidance scripts
     export PATH=$PREFIX/bin/xc-avoidance:$PATH
 fi
 
-SIP_COMMAND="$BUILD_PREFIX/bin/python -m sipbuild.tools.build"
-SITE_PKGS_PATH=$($PREFIX/bin/python -c 'import site;print(site.getsitepackages()[0])')
-EXTRA_FLAGS="--target-dir $SITE_PKGS_PATH"
-
-PYQT5_LOCATION=$($BUILD_PREFIX/bin/python -c 'import PyQt5;import os;print(os.path.join(os.path.dirname(PyQt5.__file__), "bindings"))')
-awk 'NR==25{$0="sip-include-dirs = [\"'$PYQT5_LOCATION'\"]\n"}1' pyproject.toml >  pyproject.toml.tmp
-rm pyproject.toml
-mv pyproject.toml.tmp pyproject.toml
-
-$SIP_COMMAND \
+sip-build \
 --verbose \
 --no-make \
 $EXTRA_FLAGS
 
 pushd build
-# Make sure BUILD_PREFIX sip-distinfo is called instead of the HOST one
-cat Makefile | sed -r 's|\t(.*)sip-distinfo(.*)|\t'$BUILD_PREFIX/bin/python' -m sipbuild.distinfo.main \2|' > Makefile.temp
-rm Makefile
-mv Makefile.temp Makefile
-
-# # For some reason SIP does not add the QtPrintSupport headers
-# cat QtWebEngineWidgets/Makefile | sed -r 's|INCPATH       =(.*)|INCPATH       =\1 -I'$PREFIX/include/qt/QtPrintSupport'|' > QtWebEngineWidgets/Makefile.temp
-# rm QtWebEngineWidgets/Makefile
-# mv QtWebEngineWidgets/Makefile.temp QtWebEngineWidgets/Makefile
 
 CPATH=$PREFIX/include make -j$CPU_COUNT
 make install

--- a/recipe/build-pyqtwebengine.sh
+++ b/recipe/build-pyqtwebengine.sh
@@ -2,55 +2,16 @@ set -exou
 
 pushd pyqt_webengine
 
-SIP_COMMAND="sip-build"
-EXTRA_FLAGS=""
-
-if [[ $(uname) == "Linux" ]]; then
-    USED_BUILD_PREFIX=${BUILD_PREFIX:-${PREFIX}}
-    echo USED_BUILD_PREFIX=${BUILD_PREFIX}
-
-    ln -s ${GXX} g++ || true
-    ln -s ${GCC} gcc || true
-    ln -s ${USED_BUILD_PREFIX}/bin/${HOST}-gcc-ar gcc-ar || true
-
-    export LD=${GXX}
-    export CC=${GCC}
-    export CXX=${GXX}
-    export PKG_CONFIG_EXECUTABLE=$(basename $(which pkg-config))
-
-    chmod +x g++ gcc gcc-ar
-    export PATH=${PWD}:${PATH}
-fi
-
 if [[ $(uname) == "Darwin" ]]; then
     # Use xcode-avoidance scripts
     export PATH=$PREFIX/bin/xc-avoidance:$PATH
 fi
 
-SIP_COMMAND="$BUILD_PREFIX/bin/python -m sipbuild.tools.build"
-SITE_PKGS_PATH=$($PREFIX/bin/python -c 'import site;print(site.getsitepackages()[0])')
-EXTRA_FLAGS="--target-dir $SITE_PKGS_PATH"
-
-PYQT5_LOCATION=$($PREFIX/bin/python -c 'import PyQt5;import os;print(os.path.join(os.path.dirname(PyQt5.__file__), "bindings"))')
-awk 'NR==25{$0="sip-include-dirs = [\"'$PYQT5_LOCATION'\"]\n"}1' pyproject.toml >  pyproject.toml.tmp
-rm pyproject.toml
-mv pyproject.toml.tmp pyproject.toml
-
-$SIP_COMMAND \
+sip-build \
 --verbose \
---no-make \
-$EXTRA_FLAGS
+--no-make
 
 pushd build
-# Make sure BUILD_PREFIX sip-distinfo is called instead of the HOST one
-cat Makefile | sed -r 's|\t(.*)sip-distinfo(.*)|\t'$PREFIX/bin/python' -m sipbuild.distinfo.main \2|' > Makefile.temp
-rm Makefile
-mv Makefile.temp Makefile
-
-# For some reason SIP does not add the QtPrintSupport headers
-cat QtWebEngineWidgets/Makefile | sed -r 's|INCPATH       =(.*)|INCPATH       =\1 -I'$PREFIX/include/qt/QtPrintSupport'|' > QtWebEngineWidgets/Makefile.temp
-rm QtWebEngineWidgets/Makefile
-mv QtWebEngineWidgets/Makefile.temp QtWebEngineWidgets/Makefile
 
 CPATH=$PREFIX/include make -j$CPU_COUNT
 make install

--- a/recipe/build-pyqtwebengine.sh
+++ b/recipe/build-pyqtwebengine.sh
@@ -2,6 +2,28 @@ set -exou
 
 pushd pyqt_webengine
 
+if [[ $(uname) == "Linux" ]]; then
+    USED_BUILD_PREFIX=${BUILD_PREFIX:-${PREFIX}}
+    echo USED_BUILD_PREFIX=${BUILD_PREFIX}
+
+    ln -s ${GXX} g++ || true
+    ln -s ${GCC} gcc || true
+    ln -s ${USED_BUILD_PREFIX}/bin/${HOST}-gcc-ar gcc-ar || true
+
+    export LD=${GXX}
+    export CC=${GCC}
+    export CXX=${GXX}
+    export PKG_CONFIG_EXECUTABLE=$(basename $(which pkg-config))
+
+    chmod +x g++ gcc gcc-ar
+    export PATH=${PWD}:${PATH}
+
+    SYSROOT_FLAGS="-L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64 -L ${BUILD_PREFIX}/${HOST}/sysroot/usr/lib"
+    export CFLAGS="$SYSROOT_FLAGS $CFLAGS"
+    export CXXFLAGS="$SYSROOT_FLAGS $CXXFLAGS"
+    export LDFLAGS="$SYSROOT_FLAGS $LDFLAGS"
+fi
+
 if [[ $(uname) == "Darwin" ]]; then
     # Use xcode-avoidance scripts
     export PATH=$PREFIX/bin/xc-avoidance:$PATH

--- a/recipe/build-pyqtwebengine.sh
+++ b/recipe/build-pyqtwebengine.sh
@@ -35,5 +35,10 @@ sip-build \
 
 pushd build
 
+# For some reason SIP does not add the QtPrintSupport headers
+cat QtWebEngineWidgets/Makefile | sed -r 's|INCPATH       =(.*)|INCPATH       =\1 -I'$PREFIX/include/qt/QtPrintSupport'|' > QtWebEngineWidgets/Makefile.temp
+rm QtWebEngineWidgets/Makefile
+mv QtWebEngineWidgets/Makefile.temp QtWebEngineWidgets/Makefile
+
 CPATH=$PREFIX/include make -j$CPU_COUNT
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,6 @@ outputs:
     version: {{ sip_version }}
     script: build-pyqt-sip.sh  # [not win]
     script: bld-pyqt-sip.bat  # [win]
-    build:
-      skip: true  # [py<311]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -65,7 +63,6 @@ outputs:
     script: build-pyqt.sh  # [not win]
     script: bld-pyqt.bat  # [win]
     build:
-      skip: true  # [py<311]
       entry_points:
         - pyuic5 = PyQt5.uic.pyuic:main
       run_exports:
@@ -178,7 +175,6 @@ outputs:
     script: build-pyqtwebengine.sh  # [not win]
     script: bld-pyqtwebengine.bat  # [win]
     build:
-      skip: true  # [py<311]
       run_exports:
         - {{ pin_subpackage('pyqtwebengine', max_pin='x.x') }}
       missing_dso_whitelist:
@@ -268,7 +264,6 @@ outputs:
     script: build-pyqtcharts.sh  # [not win]
     script: bld-pyqtcharts.bat  # [win]
     build:
-      skip: true  # [py<311]
       run_exports:
         - {{ pin_subpackage('pyqtchart', max_pin='x.x') }}
       missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set version = "5.15.7" %}
-{% set sip_version = "12.11.0" %}
-{% set webengine_version = "5.15.4" %}
-{% set charts_version = "5.15.5" %}
+{% set version = "5.15.10" %}
+{% set sip_version = "12.13.0" %}
+{% set webengine_version = "5.15.6" %}
+{% set charts_version = "5.15.6" %}
 # on our builders there is no X11 installed and therefore import
 # test will fail
 {% if target_platform != "linux-aarch64" and target_platform != "linux-64"%}
@@ -16,19 +16,19 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/P/PyQt{{ version[0] }}/PyQt{{ version[0] }}-{{ version }}.tar.gz
-    sha256: 755121a52b3a08cb07275c10ebb96576d36e320e572591db16cfdbc558101594
+    sha256: d46b7804b1b10a4ff91753f8113e5b5580d2b4462f3226288e2d84497334898a
     folder: pyqt
 
   - url: https://pypi.io/packages/source/P/PyQt5-sip/PyQt5_sip-{{ sip_version }}.tar.gz
-    sha256: b4710fd85b57edef716cc55fae45bfd5bfac6fc7ba91036f1dcc3f331ca0eb39
+    sha256: 7f321daf84b9c9dbca61b80e1ef37bdaffc0e93312edae2cd7da25b953971d91
     folder: pyqt_sip
 
   - url: https://pypi.io/packages/source/P/PyQtWebEngine/PyQtWebEngine-{{ webengine_version }}.tar.gz
-    sha256: cedc28f54165f4b8067652145aec7f732a17eadf6736835852868cf76119cc19
+    sha256: ae241ef2a61c782939c58b52c2aea53ad99b30f3934c8358d5e0a6ebb3fd0721
     folder: pyqt_webengine
 
   - url: https://pypi.io/packages/source/P/PyQtChart/PyQtChart-{{ charts_version }}.tar.gz
-    sha256: e2cd55a8a72cef99bc0126f3b1daa914eb5f21e20a70127b6985299f1dc50107
+    sha256: 2691796fe92a294a617592a5c5c35e785dc91f7759def9eb22da79df63762339
     folder: pyqt_charts
 
 build:
@@ -40,34 +40,32 @@ outputs:
     version: {{ sip_version }}
     script: build-pyqt-sip.sh  # [not win]
     script: bld-pyqt-sip.bat  # [win]
+    build:
+      skip: true  # [py<311]
     requirements:
       build:
         - {{ compiler('c') }}
-        - {{ compiler('cxx') }}
-        - python
-        - setuptools
-        - wheel
-        - pip
       host:
         - python
         - setuptools
         - wheel
         - pip
-        - wheel
       run:
         - python
-        - sip
-        - packaging
-        - toml
     test:
       imports:
         - PyQt5.sip
+      requires:
+        - pip
+      commands:
+        - pip check
 
   - name: pyqt
     version: {{ version }}
     script: build-pyqt.sh  # [not win]
     script: bld-pyqt.bat  # [win]
     build:
+      skip: true  # [py<311]
       entry_points:
         - pyuic5 = PyQt5.uic.pyuic:main
       run_exports:
@@ -128,36 +126,17 @@ outputs:
         - {{ cdt('xcb-util-wm-devel') }}          # [linux and not (aarch64 or x86_64)]
         - jom                                # [win]
         - make  # [not win]
-        - python
-        - pyqt-builder
         - pkg-config
-        - qt-webengine 5.15.*
-        - qt-main 5.15.*
-        - qtwebkit 5.*
-        - python
-        - dbus-python  # [unix]
-        - setuptools
-        - wheel
-        - pip
       host:
-        - pyqt-builder
         - python
-        - pip
-        - setuptools
-        - wheel
-        - sip
-        - toml
-        - pyqt-builder
-        - packaging
+        - pyqt-builder >=1.14.1,<2
+        - sip >=6.6.2,<7
         - qt-main 5.15.*
-        - qt-webengine 5.15.*
-        - qtwebkit 5.*
+        - dbus-python  # [unix]
         - {{ cdt('mesa-libgl-devel') }}          # [linux]
         - {{ cdt('mesa-libegl-devel') }}         # [linux]
       run:
         - qt-main 5.15*
-        - qt-webengine 5.15.*
-        - qtwebkit 5.*
         - python
         - {{ pin_subpackage('pyqt5-sip', exact=True) }}
     test:
@@ -186,16 +165,20 @@ outputs:
         - PyQt5.QtXml
         - PyQt5.QtXmlPatterns
 {% endif %}
+      requires:
+        - pip
       commands:
         # we don't have xvfb on our builders ... so we might ignore it ..
         - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'python pyqt_test.py' || true # [linux]
         - pyuic5 --version  # [not win]
+        - pip check
 
   - name: pyqtwebengine
     version: {{ version }}
     script: build-pyqtwebengine.sh  # [not win]
     script: bld-pyqtwebengine.bat  # [win]
     build:
+      skip: true  # [py<311]
       run_exports:
         - {{ pin_subpackage('pyqtwebengine', max_pin='x.x') }}
       missing_dso_whitelist:
@@ -253,27 +236,12 @@ outputs:
         - {{ cdt('xcb-util-wm-devel') }}          # [linux and not (aarch64 or x86_64)]
         - jom                                    # [win]
         - make  # [not win]
-        - python
-        - pyqt-builder
         - pkg-config
-        - pyqt
-        - qt-main 5.15.*
-        - qt-webengine 5.15.*
-        - qtwebkit 5.*
-        - dbus-python  # [unix]
-        - setuptools
-        - wheel
-        - pip
       host:
         - python
-        - pip
-        - setuptools
-        - wheel
-        - sip
-        - toml
-        - pyqt-builder
-        - packaging
-        - pyqt
+        - pyqt-builder >=1.9,<2
+        - sip >=5.3,<7
+        - {{ pin_subpackage('pyqt', exact=True) }}
         - qt-main 5.15.*
         - qt-webengine  5.15.*
         - {{ cdt('mesa-libgl-devel') }}          # [linux]
@@ -281,22 +249,26 @@ outputs:
       run:
         - qt-main 5.15.*
         - qt-webengine 5.15.*
-        - qtwebkit 5.*
         - python
         - {{ pin_subpackage('pyqt', max_pin='x.x') }}
-{% if enable_testingui %}
     test:
+{% if enable_testingui %}
       imports:
         - PyQt5.QtWebEngine
         - PyQt5.QtWebEngineCore
         - PyQt5.QtWebEngineWidgets
 {% endif %}
+      requires:
+        - pip
+      commands:
+        - pip check
 
   - name: pyqtchart
     version: {{ version }}
     script: build-pyqtcharts.sh  # [not win]
     script: bld-pyqtcharts.bat  # [win]
     build:
+      skip: true  # [py<311]
       run_exports:
         - {{ pin_subpackage('pyqtchart', max_pin='x.x') }}
       missing_dso_whitelist:
@@ -354,43 +326,28 @@ outputs:
         - {{ cdt('xcb-util-wm-devel') }}          # [linux and not (aarch64 or x86_64)]
         - jom                                    # [win]
         - make  # [not win]
-        - python
-        - pyqt-builder
-        - dbus-python  # [unix]
         - pkg-config
-        - pyqt
-        - qt-main 5.15.*
-        - qt-webengine 5.15.*
-        - qtwebkit 5.*
-        - setuptools
-        - wheel
-        - pip
       host:
         - python
-        - pip
-        - setuptools
-        - wheel
-        - sip
-        - toml
-        - pyqt-builder
-        - packaging
+        - pyqt-builder >=1.9,<2
+        - sip >=5.3,<7
         - qt-main 5.15.*
-        - qt-webengine 5.15.*
-        - qtwebkit 5.*
-        - pyqt
+        - {{ pin_subpackage('pyqt', exact=True) }}
         - {{ cdt('mesa-libgl-devel') }}          # [linux]
         - {{ cdt('mesa-libegl-devel') }}         # [linux]
       run:
         - qt-main 5.15.*
-        - qtwebkit 5.*
-        - qt-webengine 5.15.*
         - python
         - {{ pin_subpackage('pyqt', max_pin='x.x') }}
-{% if enable_testingui %}
     test:
+{% if enable_testingui %}
       imports:
         - PyQt5.QtChart
 {% endif %}
+      requires:
+        - pip
+      commands:
+        - pip check
 
 about:
   home: https://www.riverbankcomputing.com/software/pyqt/
@@ -398,7 +355,6 @@ about:
   license_family: GPL
   license_file: pyqt/LICENSE
   summary: Python bindings for the Qt cross platform application toolkit
-  # The remaining entries in this section are optional, but recommended.
   description: |
     PyQt5 is a comprehensive set of Python bindings for Qt v5.
     It is implemented as more than 35 extension modules and enables Python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,7 +129,6 @@ outputs:
         - pyqt-builder >=1.14.1,<2
         - sip >=6.6.2,<7
         - qt-main 5.15.*
-        - dbus-python  # [unix]
         - {{ cdt('mesa-libgl-devel') }}          # [linux]
         - {{ cdt('mesa-libegl-devel') }}         # [linux]
       run:


### PR DESCRIPTION
Changes:
- Update to 5.15.10 (required for 3.12 compatibility).
- Simplify recipe by removing stuff that should have been enabled only for cross-compilation.
- Remove dbus-python host dependency. It was not found by the build, and from what I see, this is not new. It was also not set as a run dependency.
- pyqt does not depend on qtwebengine or qtwebkit.

You would think that you could just pip install, and that it would call pyqt-builder nice and all. But it fails miserably. I tried a bit but in the end, calling sip-builder (provided by pyqt-builder) still works.

Sources available on pypi:
https://pypi.org/project/PyQt5/
https://pypi.org/project/PyQt5-sip/
https://pypi.org/project/PyQtWebEngine/
https://pypi.org/project/PyQtChart/